### PR TITLE
CodeIgntier 404 for bootstrap.min.css link fixed

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -11,6 +11,7 @@ RewriteEngine On
 # RewriteCond %{HTTP_HOST} !^www\..+$ [NC]
 # RewriteCond %{HTTP_HOST} (.+)$ [NC]
 # RewriteRule ^(.*)$ http://www.%1/$1 [R=301,L]
+RewriteCond %{REQUEST_URI} !/dist/
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 # if in web root


### PR DESCRIPTION
The line added to the public/.htaccess will bypass index.php front-controller for all link having /dist/ within its URL. Previously it was adding the index.php in the URL generating CodeIgniter 404 error.